### PR TITLE
<fix> from __future__ must come first

### DIFF
--- a/app/bookbeeper/bookservices/APIServices.py
+++ b/app/bookbeeper/bookservices/APIServices.py
@@ -1,6 +1,6 @@
-__author__ = 'keaj'
-
 from __future__ import unicode_literals
+
+__author__ = 'keaj'
 
 import base64
 import httplib2


### PR DESCRIPTION
Oops, didn't realize until I rebased my tests that I broke APIServices. :-( The error:

`SyntaxError: from __future__ imports must occur at the beginning of the file`

Fortunately, the fix is easy!
